### PR TITLE
Update dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 opencv-python
-win32api
+pywin32
 matplotlib
 seaborn


### PR DESCRIPTION
No longer win32api, now installs as pywin32 see https://pypi.org/project/pywin32/