### PR TITLE
remove unused pywin32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 opencv-python
 autopy
-pywin32
 matplotlib
 seaborn


### PR DESCRIPTION
Neat project! Hopefully this isn't an unwelcome change, but I noticed you're requiring `pywin32` which doesn't appear to be necessary and prevents your project from running on Linux. :+1: 